### PR TITLE
update tf module version to comply

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,8 +8,7 @@ locals {
 
 resource "aws_ecs_cluster" "logging_cluster" {
   name = "ecs-${local.ecs_name}"
-  capacity_providers = ["FARGATE"]
-
+  
   setting {
     name  = "containerInsights"
     value = "enabled"


### PR DESCRIPTION
Removing line 11
according to 

Error: Unsupported argument
│ 
│   on .terraform/modules/logstash_ecs/main.tf line 11, in resource "aws_ecs_cluster" "logging_cluster":
│   11:   capacity_providers = ["FARGATE"]
│ 
│ An argument named "capacity_providers" is not expected here.